### PR TITLE
Simplify test and raise error if bootstrap fails.

### DIFF
--- a/automan/automation.py
+++ b/automan/automation.py
@@ -798,9 +798,13 @@ class Automator(object):
             config_fname=args.config,
             exclude_paths=self._get_exclude_paths()
         )
+        from .cluster_manager import BootstrapError
 
         if len(args.host) > 0:
-            self.cluster_manager.add_worker(args.host, args.home, args.nfs)
+            try:
+                self.cluster_manager.add_worker(args.host, args.home, args.nfs)
+            except BootstrapError:
+                pass
             return
         elif len(args.host) == 0 and args.update_remote:
             self.cluster_manager.update(not args.no_rebuild)

--- a/automan/cluster_manager.py
+++ b/automan/cluster_manager.py
@@ -21,6 +21,10 @@ except ImportError:
     from urllib.request import urlopen
 
 
+class BootstrapError(Exception):
+    pass
+
+
 class ClusterManager(object):
     """The cluster manager class.
 
@@ -194,6 +198,7 @@ class ClusterManager(object):
                        project_name=self.project_name)
             )
             print(msg)
+            raise BootstrapError(msg)
         else:
             print("Bootstrapping {host} succeeded!".format(host=host))
 

--- a/automan/tests/test_cluster_manager.py
+++ b/automan/tests/test_cluster_manager.py
@@ -28,13 +28,8 @@ class MyClusterManager(ClusterManager):
         #!/bin/bash
 
         set -e
-        python -m venv envs/{project_name}
-        source envs/{project_name}/bin/activate
-
-        cd %s
-        python -m pip install execnet psutil
-        python setup.py install
-        """ % ROOT_DIR)
+        python -m venv --system-site-packages envs/{project_name}
+        """)
 
     UPDATE = dedent("""\
          #!/bin/bash


### PR DESCRIPTION
Currently if bootstrapping fails it just prints but it should really
raise an exception which we now do.  Also simplify the test to not
install automan etc. and instead inherit it from the parent.