### PR TITLE
Improve cluster manager extensibility.

### DIFF
--- a/automan/cluster_manager.py
+++ b/automan/cluster_manager.py
@@ -68,6 +68,11 @@ class ClusterManager(object):
     update scripts are put here and may be edited by the user for any new
     hosts.
 
+    One may override the `_get_python, _get_helper_scripts`, and
+    `_get_bootstrap_code, _get_update_code` methods to change this to use other
+    package managers like edm or conda. See the conda_cluster_manager for an
+    example.
+
     """
 
     #######################################################
@@ -202,6 +207,9 @@ class ClusterManager(object):
         else:
             print("Bootstrapping {host} succeeded!".format(host=host))
 
+    def _get_bootstrap_code(self):
+        return self.BOOTSTRAP.format(project_name=self.project_name)
+
     def _get_python(self, host, home):
         return os.path.join(
             home, self.root,
@@ -209,6 +217,9 @@ class ClusterManager(object):
                 project_name=self.project_name
             )
         )
+
+    def _get_update_code(self):
+        return self.UPDATE.format(project_name=self.project_name)
 
     def _get_helper_scripts(self):
         """Return a space separated string of script files that you need copied over to
@@ -291,8 +302,8 @@ class ClusterManager(object):
             self._sync_dir(host, local_dir, remote_dir)
 
         scripts_dir = self.scripts_dir
-        bootstrap_code = self.BOOTSTRAP.format(project_name=self.project_name)
-        update_code = self.UPDATE.format(project_name=self.project_name)
+        bootstrap_code = self._get_bootstrap_code()
+        update_code = self._get_update_code()
         scripts = {'bootstrap.sh': bootstrap_code,
                    'update.sh': update_code}
         for script, code in scripts.items():

--- a/automan/conda_cluster_manager.py
+++ b/automan/conda_cluster_manager.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from .cluster_manager import ClusterManager
 
 
-class CondaClusterManager(ClusterManager):  # pragma: no cover
+class CondaClusterManager(ClusterManager):
 
     # The path to conda root on the remote, this is a relative path
     # and is relative to the home directory.
@@ -14,7 +14,7 @@ class CondaClusterManager(ClusterManager):  # pragma: no cover
     #!/bin/bash
 
     set -e
-    CONDA_ROOT=%s
+    CONDA_ROOT={conda_root}
     ENV_FILE="{project_name}/environments.yml"
     if [ -f $ENV_FILE ] ; then
         ~/$CONDA_ROOT/bin/conda env create -q -f $ENV_FILE -n {project_name}
@@ -29,13 +29,13 @@ class CondaClusterManager(ClusterManager):  # pragma: no cover
     if [ -f "requirements.txt" ] ; then
         pip install -r requirements.txt
     fi
-    """ % CONDA_ROOT)
+    """)
 
     UPDATE = dedent("""\
     #!/bin/bash
 
     set -e
-    CONDA_ROOT=%s
+    CONDA_ROOT={conda_root}
     ENV_FILE="{project_name}/environments.yml"
     if [ -f $ENV_FILE ] ; then
         ~/$CONDA_ROOT/bin/conda env update -q -f $ENV_FILE -n {project_name}
@@ -47,8 +47,12 @@ class CondaClusterManager(ClusterManager):  # pragma: no cover
     if [ -f "requirements.txt" ] ; then
         pip install -r requirements.txt
     fi
+    """)
 
-    """ % CONDA_ROOT)
+    def _get_bootstrap_code(self):
+        return self.BOOTSTRAP.format(
+            project_name=self.project_name, conda_root=self.CONDA_ROOT
+        )
 
     def _get_python(self, host, home):
         return os.path.join(
@@ -56,6 +60,11 @@ class CondaClusterManager(ClusterManager):  # pragma: no cover
             'envs/{project_name}/bin/python'.format(
                 project_name=self.project_name
             )
+        )
+
+    def _get_update_code(self):
+        return self.UPDATE.format(
+            project_name=self.project_name, conda_root=self.CONDA_ROOT
         )
 
     def _get_helper_scripts(self):


### PR DESCRIPTION
Earlier the BOOTSTRAP code was relying on the CONDA_ROOT, this will not
work if CONDA_ROOT is changed later by a user.  We now add two private
methods `_get_bootstrap_code` and `_get_update_code` which return the
bootstrap code and this is easy to customize.