### PR TITLE
Clean dependencies on force

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+0.4
+---
+
+* Release date: Still in development.
+* Support for inter Problem/Simulation/Task dependencies.
+* Print more useful messages when running tasks.
+* Fix bug with computing the available cores.
+* Minor bug fixes.
+
+
 0.3
 ~~~~
 

--- a/automan/tests/test_automation.py
+++ b/automan/tests/test_automation.py
@@ -182,6 +182,26 @@ class TestTaskRunner(TestAutomationBase):
         # Then.
         self.assertEqual(t.todo, [])
 
+        # The output dirs should exist now.
+        for name in ('A', 'B', 'C'):
+            self.assertTrue(
+                os.path.exists(os.path.join(self.output_dir, name))
+            )
+
+        # When
+        # We set force to True.
+        task = RunAll(
+            simulation_dir=self.sim_dir, output_dir=self.output_dir,
+            problem_classes=[A, B, C], force=True
+        )
+
+        # Then
+        # Make sure that all the output directories are deleted as this will
+        for name in ('A', 'B', 'C'):
+            self.assertFalse(
+                os.path.exists(os.path.join(self.output_dir, name))
+            )
+
     def test_problem_with_bad_requires_raises_error(self):
         # Given
         class D(Problem):

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -44,6 +44,9 @@ And then run::
 
 .. _pip: https://pip.pypa.io/en/stable/
 
+If you just want to run the latest version and do not have ``git`` you can do this::
+
+  $ pip install https://github.com/pypr/automan/zipball/master
 
 Once this is done, move on to the next section that provides a gentle tutorial
 introduction to using automan.

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -656,6 +656,9 @@ The README in the directory tells you how to run the examples.
 Specifying simulation dependencies
 -----------------------------------
 
+.. versionadded:: 0.4
+   Specifying simulation dependencies was added in the 0.4 version.
+
 There are times when one simulation uses the output from another and you wish
 to execute them in the right order. This can be quite easily achieved. Here is
 a simple example from the test suite that illustrates this::
@@ -685,6 +688,9 @@ dependencies see :py:class:`automan.automation.CommandTask`
 
 Specifying inter-problem dependencies
 --------------------------------------
+
+.. versionadded:: 0.4
+   Specifying problem dependencies was added in the 0.4 version.
 
 Sometimes you may have a situation where one problem depends on the output of
 another. These may be done by overriding the ``Problem.get_requires`` method.


### PR DESCRIPTION
This is useful when you have a problem that depends on others.
Currently if you force this problem, then it will not force the other
tasks it depends on.  This means that if that problem needs to be rerun
you have to manually ask for it to be run with `-f`.  This change avoids
all that and passes along the force argument to any dependent problems,