### PR TITLE
 Fix subtle bugs in task runner.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 * Support for inter Problem/Simulation/Task dependencies.
 * Print more useful messages when running tasks.
 * Fix bug with computing the available cores.
+* Improve handling of cases when tasks fail with errors.
 * Minor bug fixes.
 
 

--- a/automan/jobs.py
+++ b/automan/jobs.py
@@ -453,10 +453,11 @@ class RemoteWorker(Worker):
 
 
 class Scheduler(object):
-    def __init__(self, root='.', worker_config=()):
+    def __init__(self, root='.', worker_config=(), wait=5):
         self.workers = deque()
         self.worker_config = list(worker_config)
         self.root = os.path.abspath(os.path.expanduser(root))
+        self.wait = wait
         self._completed_jobs = []
         self.jobs = []
 
@@ -523,7 +524,7 @@ class Scheduler(object):
     def add_worker(self, conf):
         self.worker_config.append(conf)
 
-    def submit(self, job, wait=5):
+    def submit(self, job):
         proxy = None
         slept = False
         while proxy is None:
@@ -538,7 +539,7 @@ class Scheduler(object):
                     self.jobs.append(proxy)
                     break
             else:
-                time.sleep(wait)
+                time.sleep(self.wait)
                 slept = True
                 print("\rWaiting for free worker ...", end='')
                 sys.stdout.flush()

--- a/automan/tests/test_automation.py
+++ b/automan/tests/test_automation.py
@@ -129,9 +129,8 @@ class TestTaskRunner(TestAutomationBase):
         n_errors = t.run(wait=0.1)
 
         # Then
-        # All the tasks should have been run but all of them will have errors.
-        self.assertEqual(n_errors, 3)
-        self.assertEqual(len(t.todo), 0)
+        # All the tasks may have been run but those that ran will fail.
+        self.assertEqual(n_errors + len(t.todo), 3)
 
     @mock.patch('automan.jobs.total_cores', return_value=2)
     def test_task_runner_checks_for_error_in_running_tasks(self, m_t_cores):

--- a/automan/tests/test_automation.py
+++ b/automan/tests/test_automation.py
@@ -131,6 +131,7 @@ class TestTaskRunner(TestAutomationBase):
         # Then
         # All the tasks may have been run but those that ran will fail.
         self.assertEqual(n_errors + len(t.todo), 3)
+        self.assertTrue(n_errors > 0)
 
     @mock.patch('automan.jobs.total_cores', return_value=2)
     def test_task_runner_checks_for_error_in_running_tasks(self, m_t_cores):

--- a/automan/tests/test_automation.py
+++ b/automan/tests/test_automation.py
@@ -104,13 +104,65 @@ class TestAutomationBase(unittest.TestCase):
 class TestTaskRunner(TestAutomationBase):
     def _make_scheduler(self):
         worker = dict(host='localhost')
-        s = Scheduler(root='.', worker_config=[worker])
+        s = Scheduler(root='.', worker_config=[worker], wait=0.1)
         return s
 
     def _get_time(self, path):
         with open(os.path.join(path, 'stdout.txt')) as f:
             t = float(f.read())
         return t
+
+    @mock.patch('automan.jobs.total_cores', return_value=2)
+    def test_task_runner_waits_for_tasks_in_the_end(self, m_t_cores):
+        # Given
+        s = self._make_scheduler()
+        cmd = 'python -c "import sys, time; time.sleep(0.1); sys.exit(1)"'
+        ct1_dir = os.path.join(self.sim_dir, '1')
+        ct2_dir = os.path.join(self.sim_dir, '2')
+        ct3_dir = os.path.join(self.sim_dir, '3')
+        ct1 = CommandTask(cmd, output_dir=ct1_dir)
+        ct2 = CommandTask(cmd, output_dir=ct2_dir)
+        ct3 = CommandTask(cmd, output_dir=ct3_dir)
+
+        # When
+        t = TaskRunner(tasks=[ct1, ct2, ct3], scheduler=s)
+        n_errors = t.run(wait=0.1)
+
+        # Then
+        # All the tasks should have been run but all of them will have errors.
+        self.assertEqual(n_errors, 3)
+        self.assertEqual(len(t.todo), 0)
+
+    @mock.patch('automan.jobs.total_cores', return_value=2)
+    def test_task_runner_checks_for_error_in_running_tasks(self, m_t_cores):
+        # Given
+        s = self._make_scheduler()
+        cmd = 'python -c "import sys, time; time.sleep(0.1); sys.exit(1)"'
+        ct1_dir = os.path.join(self.sim_dir, '1')
+        ct2_dir = os.path.join(self.sim_dir, '2')
+        ct3_dir = os.path.join(self.sim_dir, '3')
+        job_info = dict(n_core=2, n_thread=2)
+        ct1 = CommandTask(cmd, output_dir=ct1_dir, job_info=job_info)
+        ct2 = CommandTask(cmd, output_dir=ct2_dir, job_info=job_info)
+        ct3 = CommandTask(cmd, output_dir=ct3_dir, job_info=job_info)
+
+        # When
+        t = TaskRunner(tasks=[ct1, ct2, ct3], scheduler=s)
+
+        # Then
+        self.assertEqual(len(t.todo), 3)
+
+        # When
+        n_errors = t.run(wait=0.1)
+
+        # Then
+        # In this case, two tasks should have run and one should not have run
+        # as the other two had errors.
+        self.assertEqual(n_errors, 2)
+        self.assertEqual(len(t.todo), 1)
+        self.assertTrue(os.path.exists(ct3_dir))
+        self.assertTrue(os.path.exists(ct2_dir))
+        self.assertFalse(os.path.exists(ct1_dir))
 
     def test_task_runner_does_not_add_repeated_tasks(self):
         # Given

--- a/automan/tests/test_jobs.py
+++ b/automan/tests/test_jobs.py
@@ -23,7 +23,10 @@ def safe_rmtree(*args, **kw):
         except WindowsError:
             pass
     else:
-        shutil.rmtree(*args, **kw)
+        try:
+            shutil.rmtree(*args, **kw)
+        except OSError:
+            pass
 
 
 class TestJob(unittest.TestCase):
@@ -445,7 +448,7 @@ class TestScheduler(unittest.TestCase):
         # Given
         n_core = jobs.total_cores()
         config = [dict(host='localhost')]
-        s = jobs.Scheduler(worker_config=config)
+        s = jobs.Scheduler(worker_config=config, wait=0.5)
 
         j1 = self._make_dummy_job(n_core, sleep=0.5)
         j2 = self._make_dummy_job(n_core, sleep=0.5)
@@ -453,10 +456,10 @@ class TestScheduler(unittest.TestCase):
         j4 = self._make_dummy_job(0, sleep=0.5)
 
         # When
-        proxy1 = s.submit(j1, wait=0.5)
-        proxy2 = s.submit(j2, wait=0.5)
-        proxy3 = s.submit(j3, wait=0.5)
-        proxy4 = s.submit(j4, wait=0.5)
+        proxy1 = s.submit(j1)
+        proxy2 = s.submit(j2)
+        proxy3 = s.submit(j3)
+        proxy4 = s.submit(j4)
 
         # Then
         self.assertEqual(len(s.workers), 1)


### PR DESCRIPTION
- When launching tasks, if there are no requirements for any of the
  tasks (say if you run 3 command tasks), then the runner would not wait
  at the end and say that the tasks are finished even when they are
  still running.  This is now fixed (and tested).
- When launching tasks, we now check if any running tasks had errors so
  we can bail out sooner rather than after launching many other tasks.
- The `Scheduler.submit` does not take a wait argument as it is almost
  never used.  `wait` is now a kwarg to be passed to the `Scheduler`
  which is much more convenient.
- `TaskRunner.run` now returns the number of errors at the end so we can
  use this in tests.
- Document the `Task.complete` and `Task.run` better so it is clear what
  one should do when the task has an error.