### PR TITLE
added -del command to delete output from all host

### DIFF
--- a/automan/automation.py
+++ b/automan/automation.py
@@ -1108,6 +1108,9 @@ class Automator(object):
                 return
             elif len(args.host) == 0 and args.update_remote:
                 self.cluster_manager.update(not args.no_rebuild)
+            elif len(args.rm_remote_output) > 0:
+                self.cluster_manager.delete(
+                    self.simulation_dir, args.rm_remote_output)
 
             problem_classes = self._select_problem_classes(args.problem)
             task = RunAll(
@@ -1173,6 +1176,13 @@ class Automator(object):
             '-u', '--update-remote', action='store_true',
             dest='update_remote', default=False,
             help='Update remote worker machines.'
+        )
+        parser.add_argument(
+            '--rm-remote-output', nargs='*', action="store",
+            dest="rm_remote_output", type=str, default='',
+            help="remove output folder from the mentioned machines use"
+            "'all' to remove from all host (except localhost and host where nfs"
+            "is true)"
         )
 
         self.parser = parser

--- a/automan/tests/test_cluster_manager.py
+++ b/automan/tests/test_cluster_manager.py
@@ -187,6 +187,53 @@ class TestClusterManager(unittest.TestCase):
         dest = os.path.join(self.root, 'automan', project_name, 'script.py')
         self.assertTrue(os.path.exists(dest))
 
+    @mock.patch.object(ClusterManager, '_bootstrap')
+    @mock.patch.object(ClusterManager, '_delete_outputs')
+    def test_delete_outputs_from_hosts(
+        self, mock_delete_outputs, mock_bootstrap):
+        # Given
+        cm = ClusterManager()
+        cm.add_worker('host', home='/home/foo', nfs=False)
+        cm.add_worker('host1', home='/home/foo1', nfs=False)
+
+        # When
+        cm.delete('outputs', ['host', 'host1'])
+
+        # Then
+        mock_delete_outputs.assert_any_call('host1', '/home/foo1', 'outputs')
+        mock_delete_outputs.assert_any_call('host', '/home/foo', 'outputs')
+
+    @mock.patch.object(ClusterManager, '_bootstrap')
+    @mock.patch.object(ClusterManager, '_delete_outputs')
+    def test_do_not_delete_outputs_from_hosts_when_nfs_true(
+        self, mock_delete_outputs, mock_bootstrap):
+        # Given
+        cm = ClusterManager()
+        cm.add_worker('host', home='/home/foo', nfs=True)
+        cm.add_worker('host1', home='/home/foo1', nfs=True)
+
+        # When
+        cm.delete('outputs', ['host', 'host1'])
+
+        # Then
+        mock_delete_outputs.assert_not_called()
+
+    @mock.patch.object(ClusterManager, '_bootstrap')
+    @mock.patch.object(ClusterManager, '_delete_outputs')
+    def test_delete_outputs_from_all_hosts(
+        self, mock_delete_outputs, mock_bootstrap):
+        # Given
+        cm = ClusterManager()
+        cm.add_worker('host', home='/home/foo', nfs=False)
+        cm.add_worker('host1', home='/home/foo1', nfs=False)
+
+        # When
+        cm.delete('outputs', ['all'])
+
+        # Then
+        mock_delete_outputs.assert_any_call('host1', '/home/foo1', 'outputs')
+        mock_delete_outputs.assert_any_call('host', '/home/foo', 'outputs')
+
 
 class TestCondaClusterManager(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Use case: when user creates some files which are dumped outside the input_dir of a simulations. e.g. the pre-processing of a geometry creates a file accessible to all by dumping the final output in the parent directory. In this case it is not deleted automatically.  Use can pass this command with the host name to delete the entire outputs. This does not affect the localhost files.