### PR TITLE
Improve the utility functions

### DIFF
--- a/automan/api.py
+++ b/automan/api.py
@@ -5,7 +5,10 @@ from .automation import (  # noqa
     RunAll, Simulation, SolveProblem, Task, TaskRunner, WrapperTask
 )
 
-from .utils import compare_runs, filter_by_name, filter_cases  # noqa
+from .utils import ( # noqa
+    compare_runs, dprod, filter_by_name, filter_cases, mdict,
+    opts2path
+)
 
 from .cluster_manager import ClusterManager  # noqa
 from .conda_cluster_manager import CondaClusterManager  # noqa

--- a/automan/api.py
+++ b/automan/api.py
@@ -5,7 +5,7 @@ from .automation import (  # noqa
     RunAll, Simulation, SolveProblem, Task, TaskRunner, WrapperTask
 )
 
-from .automation import compare_runs, filter_by_name, filter_cases  # noqa
+from .utils import compare_runs, filter_by_name, filter_cases  # noqa
 
 from .cluster_manager import ClusterManager  # noqa
 from .conda_cluster_manager import CondaClusterManager  # noqa

--- a/automan/automation.py
+++ b/automan/automation.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 
 from fnmatch import fnmatch
 import glob
-import itertools
 import json
 import os
 import shlex
@@ -674,14 +673,6 @@ def kwargs_to_command_line(kwargs):
     return cmd_line
 
 
-def linestyles():
-    """Cycles over a set of possible linestyles to use for plotting.
-    """
-    ls = [dict(color=x[0], linestyle=x[1]) for x in
-          itertools.product("kbgr", ["-", "--", "-.", ":"])]
-    return itertools.cycle(ls)
-
-
 class Simulation(object):
     """A convenient class to abstract code for a particular simulation.
     Simulation objects are typically created by ``Problem`` instances in order
@@ -784,75 +775,6 @@ class Simulation(object):
             return r'%s' % param
         else:
             return r'%s=%s' % (param, self.params[param])
-
-
-def compare_runs(sims, method, labels, exact=None):
-    """Given a sequence of Simulation instances, a method name, the labels to
-    compare and an optional method name for an exact solution, this calls the
-    methods with the appropriate parameters for each simulation.
-
-    **Parameters**
-
-    sims: sequence
-        Sequence of `Simulation` objects.
-    method: str or callable
-        Name of a method on each simulation method to call for plotting.
-        Or a callable which is passed the simulation instance and any kwargs.
-    labels: sequence
-        Sequence of parameters to use as labels for the plot.
-    exact: str or callable
-        Name of a method that produces an exact solution plot
-        or a callable that will be called.
-    """
-    ls = linestyles()
-    if exact is not None:
-        if isinstance(exact, str):
-            getattr(sims[0], exact)(**next(ls))
-        else:
-            exact(sims[0], **next(ls))
-    for s in sims:
-        if isinstance(method, str):
-            m = getattr(s, method)
-            m(label=s.get_labels(labels), **next(ls))
-        else:
-            method(s, label=s.get_labels(labels), **next(ls))
-
-
-def filter_cases(runs, predicate=None, **params):
-    """Given a sequence of simulations and any additional parameters, filter
-    out all the cases having exactly those parameters and return a list of
-    them.
-
-    One may also pass a callable to filter the cases using the `predicate`
-    keyword argument. If this is not a callable, it is treated as a parameter.
-    If `predicate` is passed though, the other keyword arguments are ignored.
-
-    """
-    if predicate is not None:
-        if callable(predicate):
-            return list(filter(predicate, runs))
-        else:
-            params['predicate'] = predicate
-
-    def _check_match(run):
-        for param, expected in params.items():
-            if param not in run.params or run.params[param] != expected:
-                return False
-        return True
-
-    return list(filter(_check_match, runs))
-
-
-def filter_by_name(cases, names):
-    """Filter a sequence of Simulations by their names.  That is, if the case
-    has a name contained in the given `names`, it will be selected.
-    """
-    if isinstance(names, str):
-        names = [names]
-    return sorted(
-        [x for x in cases if x.name in names],
-        key=lambda x: names.index(x.name)
-    )
 
 
 ############################################################################

--- a/automan/tests/test_automation.py
+++ b/automan/tests/test_automation.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from automan.automation import (
     Automator, CommandTask, FileCommandTask, Problem, PySPHProblem, RunAll,
-    Simulation, SolveProblem, TaskRunner, compare_runs, filter_cases
+    Simulation, SolveProblem, TaskRunner
 )
 try:
     from automan.jobs import Scheduler, RemoteWorker
@@ -654,105 +654,6 @@ def test_simulation_get_labels():
 
     # Then
     assert l == r'nx=25, perturb=0.1, correction'
-
-
-def test_compare_runs_calls_methods_when_given_names():
-    # Given
-    sims = [mock.MagicMock(), mock.MagicMock()]
-    s0, s1 = sims
-    s0.get_labels.return_value = s1.get_labels.return_value = 'label'
-
-    # When
-    compare_runs(sims, 'fig', labels=['x'], exact='exact')
-
-    # Then
-    s0.exact.assert_called_once_with(color='k', linestyle='-')
-    s0.fig.assert_called_once_with(color='k', label='label', linestyle='--')
-    s0.get_labels.assert_called_once_with(['x'])
-    assert s1.exact.called is False
-    s1.fig.assert_called_once_with(color='k', label='label', linestyle='-.')
-    s1.get_labels.assert_called_once_with(['x'])
-
-
-def test_compare_runs_works_when_given_callables():
-    # Given
-    sims = [mock.MagicMock()]
-    s0 = sims[0]
-    s0.get_labels.return_value = 'label'
-
-    func = mock.MagicMock()
-    exact = mock.MagicMock()
-
-    # When
-    compare_runs(sims, func, labels=['x'], exact=exact)
-
-    # Then
-    exact.assert_called_once_with(s0, color='k', linestyle='-')
-    func.assert_called_once_with(s0, color='k', label='label', linestyle='--')
-    s0.get_labels.assert_called_once_with(['x'])
-
-
-def test_filter_cases_works_with_params():
-    # Given
-    sims = [Simulation(root='', base_command='python', param1=i, param2=i+1)
-            for i in range(5)]
-    # When
-    result = filter_cases(sims, param1=2)
-
-    # Then
-    assert len(result) == 1
-    assert result[0].params['param1'] == 2
-
-    # When
-    result = filter_cases(sims, param1=2, param2=2)
-
-    # Then
-    assert len(result) == 0
-
-    # When
-    result = filter_cases(sims, param1=3, param2=4)
-
-    # Then
-    assert len(result) == 1
-    assert result[0].params['param1'] == 3
-    assert result[0].params['param2'] == 4
-
-
-def test_filter_cases_works_with_predicate():
-    # Given
-    sims = [Simulation(root='', base_command='python', param1=i, param2=i+1)
-            for i in range(5)]
-
-    # When
-    result = filter_cases(
-        sims, predicate=lambda x: x.params.get('param1', 0) % 2
-    )
-
-    # Then
-    assert len(result) == 2
-    assert result[0].params['param1'] == 1
-    assert result[1].params['param1'] == 3
-
-    # When
-    result = filter_cases(
-        sims, predicate=2
-    )
-
-    # Then
-    assert len(result) == 0
-
-    # Given
-    sims = [Simulation(root='', base_command='python', predicate=i)
-            for i in range(5)]
-
-    # When
-    result = filter_cases(
-        sims, predicate=2
-    )
-
-    # Then
-    assert len(result) == 1
-    assert result[0].params['predicate'] == 2
 
 
 class TestAutomator(TestAutomationBase):

--- a/automan/tests/test_utils.py
+++ b/automan/tests/test_utils.py
@@ -1,0 +1,102 @@
+from unittest import mock
+from automan.automation import Simulation
+from automan.utils import compare_runs, filter_cases
+
+
+def test_compare_runs_calls_methods_when_given_names():
+    # Given
+    sims = [mock.MagicMock(), mock.MagicMock()]
+    s0, s1 = sims
+    s0.get_labels.return_value = s1.get_labels.return_value = 'label'
+
+    # When
+    compare_runs(sims, 'fig', labels=['x'], exact='exact')
+
+    # Then
+    s0.exact.assert_called_once_with(color='k', linestyle='-')
+    s0.fig.assert_called_once_with(color='k', label='label', linestyle='--')
+    s0.get_labels.assert_called_once_with(['x'])
+    assert s1.exact.called is False
+    s1.fig.assert_called_once_with(color='k', label='label', linestyle='-.')
+    s1.get_labels.assert_called_once_with(['x'])
+
+
+def test_compare_runs_works_when_given_callables():
+    # Given
+    sims = [mock.MagicMock()]
+    s0 = sims[0]
+    s0.get_labels.return_value = 'label'
+
+    func = mock.MagicMock()
+    exact = mock.MagicMock()
+
+    # When
+    compare_runs(sims, func, labels=['x'], exact=exact)
+
+    # Then
+    exact.assert_called_once_with(s0, color='k', linestyle='-')
+    func.assert_called_once_with(s0, color='k', label='label', linestyle='--')
+    s0.get_labels.assert_called_once_with(['x'])
+
+
+def test_filter_cases_works_with_params():
+    # Given
+    sims = [Simulation(root='', base_command='python', param1=i, param2=i+1)
+            for i in range(5)]
+    # When
+    result = filter_cases(sims, param1=2)
+
+    # Then
+    assert len(result) == 1
+    assert result[0].params['param1'] == 2
+
+    # When
+    result = filter_cases(sims, param1=2, param2=2)
+
+    # Then
+    assert len(result) == 0
+
+    # When
+    result = filter_cases(sims, param1=3, param2=4)
+
+    # Then
+    assert len(result) == 1
+    assert result[0].params['param1'] == 3
+    assert result[0].params['param2'] == 4
+
+
+def test_filter_cases_works_with_predicate():
+    # Given
+    sims = [Simulation(root='', base_command='python', param1=i, param2=i+1)
+            for i in range(5)]
+
+    # When
+    result = filter_cases(
+        sims, predicate=lambda x: x.params.get('param1', 0) % 2
+    )
+
+    # Then
+    assert len(result) == 2
+    assert result[0].params['param1'] == 1
+    assert result[1].params['param1'] == 3
+
+    # When
+    result = filter_cases(
+        sims, predicate=2
+    )
+
+    # Then
+    assert len(result) == 0
+
+    # Given
+    sims = [Simulation(root='', base_command='python', predicate=i)
+            for i in range(5)]
+
+    # When
+    result = filter_cases(
+        sims, predicate=2
+    )
+
+    # Then
+    assert len(result) == 1
+    assert result[0].params['predicate'] == 2

--- a/automan/tests/test_utils.py
+++ b/automan/tests/test_utils.py
@@ -39,6 +39,25 @@ def test_compare_runs_works_when_given_callables():
     s0.get_labels.assert_called_once_with(['x'])
 
 
+def test_compare_runs_uses_given_linestyles():
+    # Given
+    sims = [mock.MagicMock()]
+    s0 = sims[0]
+    s0.get_labels.return_value = 'label'
+
+    func = mock.MagicMock()
+    linestyles = mock.MagicMock()
+    linestyles.return_value = iter([dict(linestyle=':', color='b')])
+
+    # When
+    compare_runs(sims, func, labels=['x'], linestyles=linestyles)
+
+    # Then
+    func.assert_called_once_with(s0, color='b', label='label', linestyle=':')
+    s0.get_labels.assert_called_once_with(['x'])
+    linestyles.assert_called_once_with()
+
+
 def test_filter_cases_works_with_params():
     # Given
     sims = [Simulation(root='', base_command='python', param1=i, param2=i+1)

--- a/automan/tests/test_utils.py
+++ b/automan/tests/test_utils.py
@@ -1,6 +1,7 @@
 from unittest import mock
 from automan.automation import Simulation
-from automan.utils import compare_runs, filter_cases
+from automan.utils import (compare_runs, dprod, filter_cases, mdict,
+                           opts2path)
 
 
 def test_compare_runs_calls_methods_when_given_names():
@@ -56,6 +57,17 @@ def test_compare_runs_uses_given_linestyles():
     func.assert_called_once_with(s0, color='b', label='label', linestyle=':')
     s0.get_labels.assert_called_once_with(['x'])
     linestyles.assert_called_once_with()
+
+
+def test_dprod():
+    # Given/When
+    res = dprod(mdict(a=[1, 2], b=['xy']), mdict(c='ab'))
+    # Then
+    exp = [{'a': 1, 'b': 'xy', 'c': 'a'},
+           {'a': 1, 'b': 'xy', 'c': 'b'},
+           {'a': 2, 'b': 'xy', 'c': 'a'},
+           {'a': 2, 'b': 'xy', 'c': 'b'}]
+    assert res == exp
 
 
 def test_filter_cases_works_with_params():
@@ -119,3 +131,20 @@ def test_filter_cases_works_with_predicate():
     # Then
     assert len(result) == 1
     assert result[0].params['predicate'] == 2
+
+
+def test_mdict():
+    exp = [{'a': 1, 'b': 'x'},
+           {'a': 1, 'b': 'y'},
+           {'a': 2, 'b': 'x'},
+           {'a': 2, 'b': 'y'}]
+    assert mdict(a=[1, 2], b='xy') == exp
+
+
+def test_opts2path():
+    assert opts2path(dict(x=1, y='hello', z=0.1)) == 'x_1_hello_z_0.1'
+    assert opts2path(dict(x=1, y='hello', z=0.1), keys=['x']) == 'x_1'
+    res = opts2path(dict(x=1, y='hello', z=0.1), ignore=['x'])
+    assert res == 'hello_z_0.1'
+    res = opts2path(dict(x=1, y='hello', z=0.1), kmap=dict(x='XX'))
+    assert res == 'XX_1_hello_z_0.1'

--- a/automan/utils.py
+++ b/automan/utils.py
@@ -1,0 +1,82 @@
+"""Utility functions handy when creating automation scripts.
+"""
+import itertools
+
+
+def linestyles():
+    """Cycles over a set of possible linestyles to use for plotting.
+    """
+    ls = [dict(color=x[0], linestyle=x[1]) for x in
+          itertools.product("kbgr", ["-", "--", "-.", ":"])]
+    return itertools.cycle(ls)
+
+
+def compare_runs(sims, method, labels, exact=None, linestyles=linestyles):
+    """Given a sequence of Simulation instances, a method name, the labels to
+    compare and an optional method name for an exact solution, this calls the
+    methods with the appropriate parameters for each simulation.
+
+    **Parameters**
+
+    sims: sequence
+        Sequence of `Simulation` objects.
+    method: str or callable
+        Name of a method on each simulation method to call for plotting.
+        Or a callable which is passed the simulation instance and any kwargs.
+    labels: sequence
+        Sequence of parameters to use as labels for the plot.
+    exact: str or callable
+        Name of a method that produces an exact solution plot
+        or a callable that will be called.
+    linestyles: callable: returns an iterator of linestyle keyword arguments.
+        Defaults to the ``linestyles`` function defined in this module.
+    """
+    ls = linestyles()
+    if exact is not None:
+        if isinstance(exact, str):
+            getattr(sims[0], exact)(**next(ls))
+        else:
+            exact(sims[0], **next(ls))
+    for s in sims:
+        if isinstance(method, str):
+            m = getattr(s, method)
+            m(label=s.get_labels(labels), **next(ls))
+        else:
+            method(s, label=s.get_labels(labels), **next(ls))
+
+
+def filter_cases(runs, predicate=None, **params):
+    """Given a sequence of simulations and any additional parameters, filter
+    out all the cases having exactly those parameters and return a list of
+    them.
+
+    One may also pass a callable to filter the cases using the `predicate`
+    keyword argument. If this is not a callable, it is treated as a parameter.
+    If `predicate` is passed though, the other keyword arguments are ignored.
+
+    """
+    if predicate is not None:
+        if callable(predicate):
+            return list(filter(predicate, runs))
+        else:
+            params['predicate'] = predicate
+
+    def _check_match(run):
+        for param, expected in params.items():
+            if param not in run.params or run.params[param] != expected:
+                return False
+        return True
+
+    return list(filter(_check_match, runs))
+
+
+def filter_by_name(cases, names):
+    """Filter a sequence of Simulations by their names.  That is, if the case
+    has a name contained in the given `names`, it will be selected.
+    """
+    if isinstance(names, str):
+        names = [names]
+    return sorted(
+        [x for x in cases if x.name in names],
+        key=lambda x: names.index(x.name)
+    )

--- a/docs/source/reference/automan.rst
+++ b/docs/source/reference/automan.rst
@@ -6,6 +6,14 @@ Main automation module
    :undoc-members:
 
 
+Utility functions for automation
+=================================
+
+.. automodule:: automan.utils
+   :members:
+   :undoc-members:
+
+
 Low-level job management module
 =================================
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -418,6 +418,114 @@ There are a few more conveniences that automan provides that are useful while
 post-processing and these are discussed below.
 
 
+Generating simulations for parameter sweeps
+-------------------------------------------
+
+.. py:currentmodule:: automan.utils
+
+.. versionadded:: 0.5
+
+One of the primary advantages of automan is the ease with which one can
+perform parameter sweeps. The biggest difficulty in this case is to generate
+all the simulations easily from a set of parameters of interest. ``automan``
+provides a few convenient utility functions that make this very easy to do.
+
+We explain these functions with a simple example. Let us say we wish to
+execute a simulation with two values of a parameter (``re = 100, 200``), for
+two different set of resolutions (``nx = 50, 100``). Normally, one would need
+to create the simulations in a for loop. The :py:func:`mdict` function makes
+this very easy to do as follows::
+
+  >>> from automan.api import mdict
+  >>> opts = mdict(nx=[50, 100], re=[100, 200])
+  >>> opts
+  [{'nx': 50, 're': 100},
+  {'nx': 50, 're': 200},
+  {'nx': 100, 're': 100},
+  {'nx': 100, 're': 200}]
+
+As you can see this creates a list of dictionaries, each with the required set
+of parameters that can be passed to a :py:class:`Simulation` instance. This
+expands to any number of parameters. Note that the arguments to ``mdict``
+should be sequences which are expanded out as a product.
+
+Often you have a set of parameters that go together. For example, if we have
+two optimizers, say ``Adam`` and ``LBFGS`` and then you have to choose
+different learning rates for each, you can do the following::
+
+  >>> opts2 = mdict(optimizer=['Adam'], lr=[1e-2, 1e-3]) + \
+  ...         mdict(optimizer=['LBFGS'], lr=[1.0, 0.1])
+
+Now, let us say we want to take the product of the ``opts`` above (for the
+``nx, re`` values) along with the ``opts2`` above, we can easily do this using
+the :py:func:`dprod` like so::
+
+  >>> from automan.api import dprod
+  >>> options = dprod(opts, opts2)
+  >>> type(options)
+  list
+  >>> len(options)
+  16
+
+This will be the product of all the options and will produce 16 different
+cases as a list of dictionaries. Notice that this just takes 4 lines of code.
+We can use these list of dictionaries to create the necessary simulations
+easily. For example::
+
+  cases = [
+     Simulation(
+         root=self.input_path('unique_directory_name'),
+         base_command='python code.py',
+         **kw
+     )
+     for kw in options
+  ]
+
+With that you can create a huge number of simulations. The only issue here is
+that you need to create a unique directory name to dump the output of each
+simulation into. The :py:func:`opts2path` function provides a very convenient
+way to do this. It takes a dictionary and optional keyword arguments to
+convert the set of parameters in the dictionary into a string for use as a
+unique directory. Here is a quick example::
+
+  >>> from automan.api import opts2path
+  >>> opts2path(dict(x=1, y='hello', z=0.1))
+  'x_1_hello_z_0.1'
+
+This renders each parameter out. We can limit the string to only use certain
+keys using the ``keys`` keyword argument::
+
+  >>> opts2path(dict(x=1, y='hello', z=0.1), keys=['x'])
+  'x_1'
+
+Or we could ``ignore`` some keys::
+
+  >>> opts2path(dict(x=1, y='hello', z=0.1), ignore=['x'])
+  'hello_z_0.1'
+
+Or we could map the keys to some other string::
+
+  >>> opts2path(dict(x=1, y='hello', z=0.1), kmap=dict(x='XX'))
+  'XX_1_hello_z_0.1'
+
+
+Using this makes it very easy to generate simulation instances like so::
+
+  cases = [
+     Simulation(
+         root=self.input_path(opts2path(kw)),
+         base_command='python code.py',
+         **kw
+     )
+     for kw in options
+  ]
+
+These utility functions therefore make it very easy to easily generate a huge
+number of cases. The next section shows you how to filter these cases and then
+make comparison plots from these easily.
+
+
+
 Filtering and comparing cases
 ------------------------------
 


### PR DESCRIPTION
- Pull the existing utility functions, `filter*` and `compare_runs` into a separate`utils.py` module.
- Add kwarg to `compare_runs` to set a user-defined linestyle iterator.
- Add powerful new functions, `mdict`, `dprod`, and `opts2path` to make it easy to generate many simulations from a set of parameters.
- Document these changes.