### PR TITLE
Allow the tests to run even from an installation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest coverage
-          python setup.py develop
+          python -m pip install -v .
       - name: Run tests
         run: |
           coverage erase

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.12]
 
     runs-on: ${{ matrix.os }}
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include MANIFEST.in *.py *.rst *.txt *.yml
+include MANIFEST.in *.py *.rst *.txt *.yml *.toml
 recursive-include docs *.*
 recursive-include examples *.py *.yml *.txt *.md
 recursive-exclude examples/tutorial/.automan *.*

--- a/automan/tests/test_cluster_manager.py
+++ b/automan/tests/test_cluster_manager.py
@@ -141,6 +141,11 @@ class TestClusterManager(unittest.TestCase):
                      sys.platform.startswith('win'),
                      'Test requires Python 3.x and a non-Windows system.')
     def test_remote_bootstrap_and_sync(self):
+        if not os.path.exists('setup.py'):
+            raise unittest.SkipTest(
+                'This test requires to be run from the automan source directory.'
+                )
+
         # Given
         cm = MyClusterManager(exclude_paths=['outputs/'], testing=True)
         cm.BOOTSTRAP = cm.BOOTSTRAP.replace('ROOT', self.cwd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+    "wheel>=0.29.0",
+    "setuptools>=42.0.0"
+]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def get_version():
     return data.get('__version__')
 
 
-install_requires = ['psutil', 'execnet']
+install_requires = ['psutil', 'execnet', 'setuptools']
 tests_require = ['pytest']
 if sys.version_info.major < 3:
     tests_require.append('mock')


### PR DESCRIPTION
Currently if you run `pytest --pyargs automan` outside the source directory it will fail since once of the tests assumes that it is being run from the automan source directory. This is now skipped if there is no setup.py in the current directory.