### PR TITLE
Return key for None values in _key2name function

### DIFF
--- a/automan/utils.py
+++ b/automan/utils.py
@@ -179,6 +179,8 @@ def opts2path(opts, keys=None, ignore=None, kmap=None):
             return f'{r}_{v}'
         elif isinstance(v, str):
             return v
+        elif v is None:
+            return k
         else:
             return f'{k}_{v}'
 


### PR DESCRIPTION
Boolean arguments are specified as key=None or no_key=None. 

So, just return key instead of key_None.

If someone has generated some results and decides to upgrade Automan midway, this may break things.